### PR TITLE
change_to_pypy

### DIFF
--- a/.github/workflows/test_on_merge.yml
+++ b/.github/workflows/test_on_merge.yml
@@ -11,15 +11,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set up Python3
+    - name: Set up PyPy3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: 'pypy3.10'
 
     - name: Set up environment
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install mypy
+        python -m pip install --upgrade pip
+        python -m pip install mypy
 
     - name: Run make test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,15 @@ $(OUT).o: com
 	as -g -o $(OUT).o $(OUT).s
 
 sim: photon.py ./$(OUT).phtn
-	python3 photon.py sim ./$(OUT).phtn
+	pypy3.10 photon.py sim ./$(OUT).phtn
 
 com: photon.py ./$(OUT).phtn
-	python3 photon.py com ./$(OUT).phtn
+	pypy3.10 photon.py com ./$(OUT).phtn
 
 test: photon.py test.py
 	mypy --disallow-untyped-defs photon.py
 	mypy --disallow-untyped-defs test.py
-	python3 test.py
+	pypy3.10 test.py
 
 snap: photon.py test.py
-	python3 test.py --snapshot
+	pypy3.10 test.py --snapshot

--- a/examples/euler/problem_4.phtn
+++ b/examples/euler/problem_4.phtn
@@ -1,0 +1,16 @@
+// Solution for: https://projecteuler.net/problem=4
+
+include "math.phtn"
+include "std.phtn"
+
+100 while dup 1000 < do
+    100 while dup 1000 < do
+        dup2 * dup dup invertN == swap mem load64 > & if
+            dup2 * mem swap store64
+        end
+        1 +
+    end drop
+    1 +
+end drop
+
+mem load64 print

--- a/examples/examples_output.test
+++ b/examples/examples_output.test
@@ -99,6 +99,10 @@
  **      ******   ******** ** * *** **   *  *******  * *****   *  ** ***  **        * ***  ** ***** 
 
 end./examples/rule110.phtn
+./examples/euler/problem_4.phtn
+906609
+
+end./examples/euler/problem_4.phtn
 ./examples/euler/problem_5.phtn
 232792560
 


### PR DESCRIPTION
CPython interpreter became too slow to be used to simulate Photon. To make the simulation within acceptable time frames the interpreter is changed to PyPy.