### PR TITLE
Self host intrinsics

### DIFF
--- a/photon.phtn
+++ b/photon.phtn
@@ -232,8 +232,11 @@ proc @Op.operand Op.operand + @8 end
 proc !Op !Op.operand !Op.type end
 proc @Op dup @Op.type swap @Op.operand end
 
-// expects: type:int operand:int
+// expects: type: int, operand: int
 proc push_op
+    if op_stack_count @8 OP_STACK_CAP >= do
+        here eputs "[ERROR] Op stack overflow" eputsln 1 exit
+    end
     op_stack_count @8 sizeof(Op) * op_stack +
     dup rot swap !Op
     op_stack_count inc8

--- a/photon.phtn
+++ b/photon.phtn
@@ -22,13 +22,38 @@ macro OP_INTRINSIC  1 end
 macro OP_COUNT      2 end
 
 // Intrinsic Enum
-macro INTRINSIC_ADD      0 end
-macro INTRINSIC_PRINT    1 end
-macro INTRINSIC_SUB      2 end
-macro INTRINSIC_MUL      3 end
-macro INTRINSIC_DUP      4 end
-macro INTRINSIC_DROP     5 end
-macro INTRINSIC_COUNT    6 end
+macro INTRINSIC_ADD         0  end
+macro INTRINSIC_PRINT       1  end
+macro INTRINSIC_SUB         2  end
+macro INTRINSIC_MUL         3  end
+macro INTRINSIC_DUP         4  end
+macro INTRINSIC_DROP        5  end
+macro INTRINSIC_DIV         6  end
+macro INTRINSIC_EQUAL       7  end
+macro INTRINSIC_LT          8  end
+macro INTRINSIC_GT          9  end
+macro INTRINSIC_LTE         10 end
+macro INTRINSIC_GTE         11 end
+macro INTRINSIC_NE          12 end
+macro INTRINSIC_AND         13 end
+macro INTRINSIC_OR          14 end
+macro INTRINSIC_BITNOT      15 end
+macro INTRINSIC_SHIFT_RIGHT 16 end
+macro INTRINSIC_SHIFT_LEFT  17 end
+macro INTRINSIC_SWAP        18 end
+macro INTRINSIC_OVER        19 end
+macro INTRINSIC_ROT         20 end
+macro INTRINSIC_SYSCALL0    21 end
+macro INTRINSIC_SYSCALL1    22 end
+macro INTRINSIC_SYSCALL2    23 end
+macro INTRINSIC_SYSCALL3    24 end
+macro INTRINSIC_SYSCALL4    25 end
+macro INTRINSIC_SYSCALL5    26 end
+macro INTRINSIC_SYSCALL6    27 end
+macro INTRINSIC_CAST_PTR    28 end
+macro INTRINSIC_CAST_INT    29 end
+macro INTRINSIC_CAST_BOOL   30 end
+macro INTRINSIC_COUNT       31 end
 
 // Memory layout
 memory writed_buffer PUTD_BUFFER_CAP end
@@ -238,6 +263,21 @@ proc report_error // n: int, s: ptr -> None
     "[ERROR] " eputs
 end
 
+proc get_word_as_int // None -> int
+    0 0 while dup word @Str.length < do
+        swap 10 * swap
+        dup word @Str.data + @
+        if dup isdigit not do
+            // TODO: Add a parse_int proc to std
+             report_error "Unknown word: " eputs word @Str eputsln
+            1 exit
+        end
+        '0' - rot +
+        swap
+        1 +
+    end drop
+end
+
 proc print_usage
     "Usage: photon.py <SUBCOMMAND>\n" puts
     "Subcommands:\n" puts
@@ -328,7 +368,7 @@ proc simulate_program
         if dup @Op.type OP_PUSH_INT == do
             dup @Op.operand sim_stack_push
         elif dup @Op.type OP_INTRINSIC == do
-            here 6 INTRINSIC_COUNT assert_expected_int
+            here 31 INTRINSIC_COUNT assert_expected_int
             if dup @Op.operand INTRINSIC_ADD == do
                 sim_stack_pop
                 sim_stack_pop
@@ -356,6 +396,144 @@ proc simulate_program
                 dup
                 sim_stack_push
                 sim_stack_push
+            elif dup @Op.operand INTRINSIC_DIV == do
+                sim_stack_pop
+                sim_stack_pop
+                swap
+                /
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_EQUAL == do
+                sim_stack_pop
+                sim_stack_pop
+                ==
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_LT == do
+                sim_stack_pop
+                sim_stack_pop
+                >
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_GT == do
+                sim_stack_pop
+                sim_stack_pop
+                <
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_LTE == do
+                sim_stack_pop
+                sim_stack_pop
+                >=
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_GTE == do
+                sim_stack_pop
+                sim_stack_pop
+                <=
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_NE == do
+                sim_stack_pop
+                sim_stack_pop
+                !=
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_AND == do
+                sim_stack_pop
+                sim_stack_pop
+                and
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_OR == do
+                sim_stack_pop
+                sim_stack_pop
+                or
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_BITNOT == do
+                sim_stack_pop
+                bnot
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SHIFT_RIGHT == do
+                sim_stack_pop
+                sim_stack_pop
+                swap
+                >>
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SHIFT_LEFT == do
+                sim_stack_pop
+                sim_stack_pop
+                swap
+                <<
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SWAP == do
+                sim_stack_pop
+                sim_stack_pop
+                swap
+                sim_stack_push
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_OVER == do
+                sim_stack_pop
+                sim_stack_pop
+                over
+                sim_stack_push
+                sim_stack_push
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_ROT == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                rot
+                sim_stack_push
+                sim_stack_push
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL0 == do
+                sim_stack_pop
+                syscall0
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL1 == do
+                sim_stack_pop
+                sim_stack_pop
+                syscall1
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL2 == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                syscall2
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL3 == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                syscall3
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL4 == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                syscall4
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL5 == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                syscall5
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_SYSCALL6 == do
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                sim_stack_pop
+                syscall6
+                sim_stack_push
+            elif dup @Op.operand INTRINSIC_CAST_PTR == do
+                NOP
+            elif dup @Op.operand INTRINSIC_CAST_INT == do
+                NOP
+            elif dup @Op.operand INTRINSIC_CAST_BOOL == do
+                NOP
             else "Unhandled Intrinsic: " eputs dup @Op.operand eputd "\n" eputs 1 exit end
         else "Unhandled Operation: " eputs dup @Op.type eputd "\n" eputs 1 exit end drop
         1 +
@@ -373,7 +551,7 @@ proc compile_program
             "   ldr x0, =" write_fd dup @Op.operand writed_fd "\n" write_fd
             "   push x0\n" write_fd
         elif dup @Op.type OP_INTRINSIC == do
-            here 6 INTRINSIC_COUNT assert_expected_int
+            here 31 INTRINSIC_COUNT assert_expected_int
             if dup @Op.operand INTRINSIC_ADD == do
                 "   ;; -- add --\n" write_fd
                 "   pop x0\n" write_fd
@@ -404,6 +582,187 @@ proc compile_program
                 "   pop x0\n" write_fd
                 "   push x0\n" write_fd
                 "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_DIV == do
+                "   ;; -- div --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   udiv x0, x1, x0\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_EQUAL == do
+                "   ;; -- equal --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x0, x1\n" write_fd
+                "   cset x0, eq\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_LT == do
+                "   ;; -- lt --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x1, x0\n" write_fd
+                "   cset x0, lt\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_GT == do
+                "   ;; -- gt --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x1, x0\n" write_fd
+                "   cset x0, gt\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_LTE == do
+                "   ;; -- lte --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x1, x0\n" write_fd
+                "   cset x0, le\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_GTE == do
+                "   ;; -- gte --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x1, x0\n" write_fd
+                "   cset x0, ge\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_NE == do
+                "   ;; -- not equal --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   cmp x0, x1\n" write_fd
+                "   cset x0, ne\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_AND == do
+                "   ;; -- and --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   and x0, x0, x1\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_OR == do
+                "   ;; -- or --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   orr x0, x0, x1\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_BITNOT == do
+                "   ;; -- bitnot --\n" write_fd
+                "   pop x0\n" write_fd
+                "   mvn x0, x0\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SHIFT_RIGHT == do
+                "   ;; -- shift right --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   lsr x0, x1, x0\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SHIFT_LEFT == do
+                "   ;; -- shift left --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   lsl x0, x1, x0\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SWAP == do
+                "   ;; -- swap --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   push x0\n" write_fd
+                "   push x1\n" write_fd
+            elif dup @Op.operand INTRINSIC_OVER == do
+                "   ;; -- over --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   push x1\n" write_fd
+                "   push x0\n" write_fd
+                "   push x1\n" write_fd
+            elif dup @Op.operand INTRINSIC_ROT == do
+                "   ;; -- rot --\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   pop x2\n" write_fd
+                "   push x1\n" write_fd
+                "   push x0\n" write_fd
+                "   push x2\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL0 == do
+                "   ;; -- syscall0 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL1 == do
+                "   ;; -- syscall1 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL2 == do
+                "   ;; -- syscall2 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL3 == do
+                "   ;; -- syscall3 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   pop x2\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL4 == do
+                "   ;; -- syscall4 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   pop x2\n" write_fd
+                "   pop x3\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL5 == do
+                "   ;; -- syscall5 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   pop x2\n" write_fd
+                "   pop x3\n" write_fd
+                "   pop x4\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_SYSCALL6 == do
+                "   ;; -- syscall6 --\n" write_fd
+                "   pop x16\n" write_fd
+                "   pop x0\n" write_fd
+                "   pop x1\n" write_fd
+                "   pop x2\n" write_fd
+                "   pop x3\n" write_fd
+                "   pop x4\n" write_fd
+                "   pop x5\n" write_fd
+                "   svc #0\n" write_fd
+                "   b.cc return_ok_" write_fd over writed_fd "\n" write_fd
+                "   mov x0, #-1\n" write_fd
+                "return_ok_" write_fd over writed_fd ":\n" write_fd
+                "   push x0\n" write_fd
+            elif dup @Op.operand INTRINSIC_CAST_PTR == do
+                "   ;; -- cast ptr --\n" write_fd
+            elif dup @Op.operand INTRINSIC_CAST_INT == do
+                "   ;; -- cast int --\n" write_fd
+            elif dup @Op.operand INTRINSIC_CAST_BOOL == do
+                "   ;; -- cast ptr --\n" write_fd
            else "Unhandled Intrinsic: " eputs dup @Op.operand eputd "\n" eputs  1 exit end
         else "Unhandled Operation: " eputs dup @Op.type eputd "\n" eputs  1 exit end drop
         1 +
@@ -424,14 +783,15 @@ end
 // Expects that line, word are allocated
 proc parse_file_as_op
     here 2 OP_COUNT assert_expected_int
-    here 6 INTRINSIC_COUNT assert_expected_int
+    here 31 INTRINSIC_COUNT assert_expected_int
     main_filename @8 ->ptr loc !Loc.filename
     0 while content Str.length @8 0 > do
         dup loc !Loc.line_num
         line content '\n' Str.chop_until()
-        0 while line Str.length @8 0 > do
-            dup loc !Loc.col_num
+        line @Str.data
+        while line Str.length @8 0 > do
             line Str.left_strip()
+            dup line @Str.data swap - loc !Loc.col_num
             word line ' ' Str.chop_until()
             if word @Str "+" Str.equal() do
                 OP_INTRINSIC INTRINSIC_ADD push_op
@@ -445,10 +805,59 @@ proc parse_file_as_op
                 OP_INTRINSIC INTRINSIC_DUP push_op
             elif word @Str "drop" Str.equal() do
                 OP_INTRINSIC INTRINSIC_DROP push_op
+            elif word @Str "/" Str.equal() do
+                OP_INTRINSIC INTRINSIC_DIV push_op
+            elif word @Str "==" Str.equal() do
+                OP_INTRINSIC INTRINSIC_EQUAL push_op
+            elif word @Str "<" Str.equal() do
+                OP_INTRINSIC INTRINSIC_LT push_op
+            elif word @Str ">" Str.equal() do
+                OP_INTRINSIC INTRINSIC_GT push_op
+            elif word @Str "<=" Str.equal() do
+                OP_INTRINSIC INTRINSIC_LTE push_op
+            elif word @Str ">=" Str.equal() do
+                OP_INTRINSIC INTRINSIC_GTE push_op
+            elif word @Str "!=" Str.equal() do
+                OP_INTRINSIC INTRINSIC_NE push_op
+            elif word @Str "and" Str.equal() do
+                OP_INTRINSIC INTRINSIC_AND push_op
+            elif word @Str "or" Str.equal() do
+                OP_INTRINSIC INTRINSIC_OR push_op
+            elif word @Str "bnot" Str.equal() do
+                OP_INTRINSIC INTRINSIC_BITNOT push_op
+            elif word @Str ">>" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SHIFT_RIGHT push_op
+            elif word @Str "<<" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SHIFT_LEFT push_op
+            elif word @Str "swap" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SWAP push_op
+            elif word @Str "over" Str.equal() do
+                OP_INTRINSIC INTRINSIC_OVER push_op
+            elif word @Str "rot" Str.equal() do
+                OP_INTRINSIC INTRINSIC_ROT push_op
+            elif word @Str "syscall0" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL0 push_op
+            elif word @Str "syscall1" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL1 push_op
+            elif word @Str "syscall2" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL2 push_op
+            elif word @Str "syscall3" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL3 push_op
+            elif word @Str "syscall4" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL4 push_op
+            elif word @Str "syscall5" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL5 push_op
+            elif word @Str "syscall6" Str.equal() do
+                OP_INTRINSIC INTRINSIC_SYSCALL6 push_op
+            elif word @Str "->ptr" Str.equal() do
+                OP_INTRINSIC INTRINSIC_CAST_PTR push_op
+            elif word @Str "->int" Str.equal() do
+                OP_INTRINSIC INTRINSIC_CAST_INT push_op
+            elif word @Str "->bool" Str.equal() do
+                OP_INTRINSIC INTRINSIC_CAST_BOOL push_op
             else
-                OP_PUSH_INT word @Str Str.parse_int() push_op
+                OP_PUSH_INT get_word_as_int push_op
             end
-            1 +
         end drop
         1 +
     end drop

--- a/photon.py
+++ b/photon.py
@@ -108,6 +108,7 @@ class Intrinsic(Enum):
     SYSCALL2 = auto()
     SYSCALL3 = auto()
     SYSCALL4 = auto()
+    SYSCALL5 = auto()
     SYSCALL6 = auto()
     ARGC = auto()
     ARGV = auto()
@@ -250,6 +251,7 @@ INTRINSIC_NAMES = {
     'syscall2': Intrinsic.SYSCALL2,
     'syscall3': Intrinsic.SYSCALL3,
     'syscall4': Intrinsic.SYSCALL4,
+    'syscall5': Intrinsic.SYSCALL5,
     'syscall6': Intrinsic.SYSCALL6,
     'argc': Intrinsic.ARGC,
     'argv': Intrinsic.ARGV,
@@ -451,7 +453,7 @@ def type_check_program(program: Program, debug: bool = False) -> None:
             i = return_stack.pop()
             traceback_stack.pop()
         elif op.type == OpType.INTRINSIC:
-            assert len(Intrinsic) == 41, 'Exhaustive handling of intrinsics in type check'
+            assert len(Intrinsic) == 42, 'Exhaustive handling of intrinsics in type check'
             if op.operand == Intrinsic.ADD:
                 ensure_argument_count(len(stack), op, 2)
                 a_type, a_loc = stack.pop()
@@ -845,6 +847,28 @@ def type_check_program(program: Program, debug: bool = False) -> None:
                         f'{(arg1_type.name, arg2_type.name, arg3_type.name, arg4_type.name, syscall_type.name)}',
                         op.token)
                 stack.append((DataType.INT, op.token))
+            elif op.operand == Intrinsic.SYSCALL5:
+                ensure_argument_count(len(stack), op, 6)
+                syscall_type, syscall_loc = stack.pop()
+                arg5_type, arg5_loc = stack.pop()
+                arg4_type, arg4_loc = stack.pop()
+                arg3_type, arg3_loc = stack.pop()
+                arg2_type, arg2_loc = stack.pop()
+                arg1_type, arg1_loc = stack.pop()
+                if syscall_type != DataType.INT:
+                    if debug:
+                        notify_argument_origin(arg1_loc, order=1)
+                        notify_argument_origin(arg2_loc, order=2)
+                        notify_argument_origin(arg3_loc, order=3)
+                        notify_argument_origin(arg4_loc, order=4)
+                        notify_argument_origin(arg5_loc, order=5)
+                        notify_argument_origin(syscall_loc, order=6)
+                    raise_error(
+                        f'Invalid argument types for `{op.name}`: '
+                        f'{arg1_type.name, arg2_type.name, arg3_type.name, arg4_type.name}'
+                        f'{arg5_type.name, syscall_type.name}',
+                        op.token)
+                stack.append((DataType.INT, op.token))
             elif op.operand == Intrinsic.SYSCALL6:
                 ensure_argument_count(len(stack), op, 7)
                 syscall_type, syscall_loc = stack.pop()
@@ -962,7 +986,7 @@ def simulate_little_endian_macos(program: Program, input_arguments: List[str]) -
         elif op.type == OpType.RET:
             i = return_stack.pop()
         elif op.type == OpType.INTRINSIC:
-            assert len(Intrinsic) == 41, 'Exhaustive handling of intrinsics in simulation'
+            assert len(Intrinsic) == 42, 'Exhaustive handling of intrinsics in simulation'
             if op.operand == Intrinsic.ADD:
                 a = stack.pop()
                 b = stack.pop()
@@ -1244,7 +1268,7 @@ def compile_program(program: Program, out_name: str) -> None:
             write_level1(f'ret')
             write_base(f'ret_{i}:')
         elif op.type == OpType.INTRINSIC:
-            assert len(Intrinsic) == 41, 'Exhaustive handling of intrinsics in simulation'
+            assert len(Intrinsic) == 42, 'Exhaustive handling of intrinsics in simulation'
             if op.operand == Intrinsic.ADD:
                 write_level1('pop x0')
                 write_level1('pop x1')
@@ -1451,6 +1475,18 @@ def compile_program(program: Program, out_name: str) -> None:
                 write_level1('pop x1')
                 write_level1('pop x2')
                 write_level1('pop x3')
+                write_level1('svc #0')
+                write_level1(f'b.cc return_ok_{i}')
+                write_level1('mov x0, #-1')
+                write_base(f'return_ok_{i}:')
+                write_level1('push x0')
+            elif op.operand == Intrinsic.SYSCALL5:
+                write_level1('pop x16')
+                write_level1('pop x0')
+                write_level1('pop x1')
+                write_level1('pop x2')
+                write_level1('pop x3')
+                write_level1('pop x4')
                 write_level1('svc #0')
                 write_level1(f'b.cc return_ok_{i}')
                 write_level1('mov x0, #-1')

--- a/std/std.phtn
+++ b/std/std.phtn
@@ -12,6 +12,7 @@ include "macos.phtn"
 macro NULL 0 end
 macro true 0 0 == end
 macro false 0 0 != end
+macro NOP end
 
 // IO Buffers
 macro stdin 0 end
@@ -201,23 +202,6 @@ proc Str.equal() // n1: int, s1: ptr, n2: int, s2: ptr -> bool
     else
         false
     end
-end
-
-memory parse_int_var sizeof(Str) end
-proc Str.parse_int() // n: int, s: ptr -> int
-    parse_int_var !Str
-    0 0 while dup parse_int_var @Str.length < do
-        dup parse_int_var @Str.data + @
-        if dup isdigit not do
-            // TODO: Fix error reporting for photon.phtn
-            // report_error "Unknown word: " eputs word @Str eputsln
-            "[ERROR] Unknown word: " eputs parse_int_var @Str eputsln
-            1 exit
-        end
-        '0' - rot +
-        swap
-        1 +
-    end drop
 end
 
 proc strlen


### PR DESCRIPTION
Add Intrinsics which do not require memory or string support to photon.phtn.
Basically all intrinsics except store and load variations,  argv, argc and here.